### PR TITLE
[SASS-10574] Add supporting agent delegated auth code to AuthAction

### DIFF
--- a/app/common/EnrolmentCommon.scala
+++ b/app/common/EnrolmentCommon.scala
@@ -18,6 +18,7 @@ package common
 
 object EnrolmentKeys {
   val Individual = "HMRC-MTD-IT"
+  val SupportingAgent = "HMRC-MTD-IT-SUPP"
   val Agent = "HMRC-AS-AGENT"
   val nino = "HMRC-NI"
 }
@@ -26,4 +27,9 @@ object EnrolmentIdentifiers {
   val individualId = "MTDITID"
   val agentReference = "AgentReferenceNumber"
   val nino = "NINO"
+}
+
+object DelegatedAuthRules {
+  val agentDelegatedAuthRule = "mtd-it-auth"
+  val supportingAgentDelegatedAuthRule = "mtd-it-auth-supp"
 }

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -37,7 +37,9 @@ class BackendAppConfig @Inject()(config: Configuration, servicesConfig: Services
   val additionalInfoBaseUrl: String = servicesConfig.baseUrl("income-tax-additional-information")
   val tailoringPhaseIIBaseUrl: String = servicesConfig.baseUrl("income-tax-tailor-return")
 
+  //Feature switching
   val auditingEnabled: Boolean = config.get[Boolean]("auditing.enabled")
+  def emaSupportingAgentsEnabled: Boolean = config.get[Boolean]("feature-switch.ema-supporting-agents-enabled")
 
   //Mongo config
   lazy val encryptionKey: String = servicesConfig.getString("mongodb.encryption.key")
@@ -61,7 +63,9 @@ trait AppConfig {
   val stateBenefitsBaseUrl: String
   val tailoringPhaseIIBaseUrl: String
 
+  //Feature switching
   val auditingEnabled: Boolean
+  def emaSupportingAgentsEnabled: Boolean
 
   //Mongo config
   val encryptionKey: String

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -21,7 +21,8 @@ import play.api.mvc.{Request, WrappedRequest}
 case class User[T](mtditid: String,
                    arn: Option[String],
                    nino: String,
-                   sessionId: String)
+                   sessionId: String,
+                   isSupportingAgent: Boolean = false)
                   (implicit request: Request[T]) extends WrappedRequest[T](request) {
   def isAgent: Boolean = arn.nonEmpty
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -127,3 +127,7 @@ microservice {
   }
 }
 
+feature-switch {
+  ema-supporting-agents-enabled = true
+}
+

--- a/test/common/EnrolmentCommonSpec.scala
+++ b/test/common/EnrolmentCommonSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class EnrolmentCommonSpec extends AnyWordSpec with Matchers {
+
+  "EnrolmentKeys" should {
+    "have the correct values" in {
+      EnrolmentKeys.Individual mustBe "HMRC-MTD-IT"
+      EnrolmentKeys.SupportingAgent mustBe "HMRC-MTD-IT-SUPP"
+      EnrolmentKeys.Agent mustBe "HMRC-AS-AGENT"
+      EnrolmentKeys.nino mustBe "HMRC-NI"
+    }
+  }
+
+  "EnrolmentIdentifiers" should {
+    "have the correct values" in {
+      EnrolmentIdentifiers.individualId mustBe "MTDITID"
+      EnrolmentIdentifiers.agentReference mustBe "AgentReferenceNumber"
+      EnrolmentIdentifiers.nino mustBe "NINO"
+    }
+  }
+
+  "DelegatedAuthRules" should {
+    "have the correct values" in {
+      DelegatedAuthRules.agentDelegatedAuthRule mustBe "mtd-it-auth"
+      DelegatedAuthRules.supportingAgentDelegatedAuthRule mustBe "mtd-it-auth-supp"
+    }
+  }
+
+}

--- a/test/controllers/ExcludeJourneyControllerSpec.scala
+++ b/test/controllers/ExcludeJourneyControllerSpec.scala
@@ -26,7 +26,7 @@ import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import services.ExcludeJourneyService
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.TestUtils
+import utils.{MockAppConfig, TestUtils}
 
 import java.time.Instant
 import scala.concurrent.Future
@@ -42,7 +42,7 @@ class ExcludeJourneyControllerSpec extends TestUtils {
   private val taxYear = 2023
   private lazy val mockService = mock[ExcludeJourneyService]
 
-  private lazy val auth = new AuthorisedAction()(mockAuthConnector, defaultActionBuilder, mockControllerComponents)
+  private lazy val auth = new AuthorisedAction()(mockAuthConnector, defaultActionBuilder, new MockAppConfig(), mockControllerComponents)
 
   private lazy val controller = new ExcludeJourneyController(
     mockControllerComponents,

--- a/test/utils/MockAppConfig.scala
+++ b/test/utils/MockAppConfig.scala
@@ -19,7 +19,8 @@ package utils
 import config.AppConfig
 import org.scalamock.scalatest.MockFactory
 
-class MockAppConfig(isEncrypted: Boolean = true) extends AppConfig with MockFactory {
+class MockAppConfig(isEncrypted: Boolean = true,
+                    supportingAgentsEnabled: Boolean = false) extends AppConfig with MockFactory {
 
   private val host: String = "http://localhost:11111"
 
@@ -37,6 +38,7 @@ class MockAppConfig(isEncrypted: Boolean = true) extends AppConfig with MockFact
 
 
   override val auditingEnabled: Boolean = true
+  override val emaSupportingAgentsEnabled: Boolean = supportingAgentsEnabled
 
   override lazy val encryptionKey: String = "encryptionKey12345"
   override lazy val mongoTTL: Int = 1550


### PR DESCRIPTION
### Description
Adds a recovery block for when the Agent authentication fails to check a Feature Switch to see if EMA Supporting Agent is enabled. If it is, then it makes the call to Auth to check for the supporting agent delegated authority. If this is successful, it executes the block. If it fails, then unauthorised is returned.

This is an initial implementation, this may need to be refactored if specific endpoints required restrictions. As currently, this implementation is global config at microservice level, there is not specific grants to speficic routes/controllers within this microservice yet. 

Associated app-config PRs:
- https://github.com/hmrc/app-config-base/pull/11360

Add a link to the relevant story in Jira:
- [SASS-10448](https://jira.tools.tax.service.gov.uk/browse/SASS-10448)

### Checklist PR Reviewer
##### Before Reviewing
- [ ]  Have you pulled the branch down?
- [ ]  Have you assigned yourself to the PR?
- [ ]  Have you moved the task to “in review” on JIRA?
- [ ]  Have you checked to ensure all dependencies are up to date?
- [ ]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [ ]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [ ]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [ ]  Have you addressed warnings where appropriate?
- [ ]  Have you rebased against the current version of main?
- [ ]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
