### PR TITLE
[SASS-11579] Add logic to handle the propery talk list response based on the tailoring selection

### DIFF
--- a/app/connectors/PropertyTaskListDataConnector.scala
+++ b/app/connectors/PropertyTaskListDataConnector.scala
@@ -28,7 +28,7 @@ class PropertyTaskListDataConnector @Inject()(http: HttpClientV2,
                                               config: AppConfig)(implicit ec: ExecutionContext) extends Connector {
 
   def get(taxYear: Int,nino:String)(implicit hc: HeaderCarrier): Future[SeqOfTaskListSection] = {
-    val taskListDataUrl = config.employmentBaseUrl + s"/income-tax-property/$taxYear/tasks/$nino"
+    val taskListDataUrl = config.propertyBaseUrl + s"/income-tax-property/$taxYear/tasks/$nino"
     http
       .get(url"$taskListDataUrl")(addHeadersToHeaderCarrier(taskListDataUrl))
       .execute[SeqOfTaskListSection]

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -10,7 +10,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] %date{ISO8601} %message %replace(exception=[%xException]){'^exception=\[\]$',''} %n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Added logic to render UKProperty, ForeignProperty or UKForeignProperty task list entry.

Should only show the row related to the combination of options selected via the tailoring µService. I.e., if they initially went through `UK` journey but then remembered they need to add `NonUK` too. Then the tailoring service entry should take precedence and show the `UkForeignProperty` (the both journey) as Not Started.

This is a little confusing, and I'm not sure this is the best approach long term - but this fits in with the way the existing pattern that has been worked for this Common Task List.

_I actually wonder long term whether `income-tax-property` BE µService should check which options have been selected via tailoring - but that would mean further coupling more µServices together... 🤷‍♂️_